### PR TITLE
bug: update readme Install All section

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,12 +51,12 @@ To install all the downloaded packages use the following command:
   
 ```sh
 # for mandatory files 
- sudo ./download_install.sh ../download_links/mandatory_download_links.txt ~/Downloads/logic_content 
+ sudo ~/Downloads/lpx_links/app/download_install.sh ~/Desktop/lpx_download_links/mandatory_download_links.txt ~/Downloads/logic_content 
 ```  
 
 ```sh
 # for all the packages
- sudo ./download_install.sh ../download_links/all_download_links.txt ~/Downloads/logic_content 
+ sudo ~/Downloads/lpx_links/app/download_install.sh ~/Desktop/lpx_download_links/all_download_links.txt ~/Downloads/logic_content 
 ```  
   
 ### Development  

--- a/README.md
+++ b/README.md
@@ -49,8 +49,14 @@ aria2c -c -i ~/Desktop/lpx_download_links/all_download_links.txt -d ~/Downloads/
   
 To install all the downloaded packages use the following command:  
   
-```sh  
- sudo ./download_install.sh ../download_links/links.txt ../LogicX  
+```sh
+# for mandatory files 
+ sudo ./download_install.sh ../download_links/mandatory_download_links.txt ~/Downloads/logic_content 
+```  
+
+```sh
+# for all the packages
+ sudo ./download_install.sh ../download_links/all_download_links.txt ~/Downloads/logic_content 
 ```  
   
 ### Development  


### PR DESCRIPTION
Problem: Various Issues indicate users have a problem with unpacking the installed packages.

Reason: Downloaded packages actually goes t o`~/Downloads/logic_content` instead of `~/Downloads/lpx_links/LogicX`

Fix: updated file absolute paths for installing packages

Ideally, this should be fixed at `lpx_links.rb` file to automate the steps

Related Open Issues:
https://github.com/davidteren/lpx_links/issues/16
https://github.com/davidteren/lpx_links/issues/15
https://github.com/davidteren/lpx_links/issues/14