### PR TITLE
Adding logic to resolve relative parents in download URLs and updating README

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Simply open the terminal and paste the command below.
   
 ```  
   
-To download I recomend using *aria2*   
+To download I recommend using *aria2*
 - Simply download & install - [aria2 ver1.33.0 installer](https://github.com/aria2/aria2/releases/download/release-1.33.0/aria2-1.33.0-osx-darwin.dmg)  
 
 
@@ -32,17 +32,18 @@ To download I recomend using *aria2*
    
 ```sh  
 # To only download the mandatory files (32)
-aria2c -c -i ~/Desktop/lpx_download_links/mandatory_download_links.txt -d ~/Downloads/logic_content
+aria2c -c --auto-file-renaming=false -i ~/Desktop/lpx_download_links/mandatory_download_links.txt -d ~/Downloads/logic_content
 
 # To download all the packages
-aria2c -c -i ~/Desktop/lpx_download_links/all_download_links.txt -d ~/Downloads/logic_content 
+aria2c -c --auto-file-renaming=false -i ~/Desktop/lpx_download_links/all_download_links.txt -d ~/Downloads/logic_content
 ```
 
      
-  
-- -c tells arai2 to continue/resume downloads.  
- - -i is the path to the file with list of downloads.  
- - -d is the path to where you want the downloaded files.   
+
+ - -c tells aria2 to continue/resume downloads
+ - --auto-file-renaming=false ensures that files will never be redownloaded if they already exist in the target directory
+ - -i is the path to the file with list of downloads
+ - -d is the path to where you want the downloaded files
      
   ![aria2 download example](https://github.com/davidteren/lpx_links/blob/master/images/aria2_example.png?raw=true)
 ### Install All  


### PR DESCRIPTION
@davidteren - I encountered an error when running this utility, and I'm fixing it here. Please review when you get the chance.

To summarize, I encountered JSON array elements from the parsed plist that look like this:
```
  "Logic9LegacyContentPackage": {
    "InstalledSize": 3304631310,
    "IsMandatory": false,
    "DownloadName": "../lp10_ms3_content_2013/MAContent10_Logic9Legacy.pkg",
    "DownloadSize": 2548058487,
    "FileCheck": "/Library/Application Support/Logic/Channel Strip Settings/Instrument/01 Logic Instruments/ES 1 Subtractive Synth.cst",
    "PackageID": "com.apple.pkg.MAContent10_Logic9Legacy"
  },
```

Note the leading "../" in the "DownloadName" value, denoting that the path should be resolving a relative parent that is not visible here. Downloads for these entries (a total of 16 for me) obviously failed, because "http://www.sample.com/this/../path/is/invalid" will bomb most download utilities like aria2 and cURL.

I've made the changes here to resolve relative parents, along with some README improvements.