### PR TITLE
Update download_install.sh

### DIFF
--- a/download_install.sh
+++ b/download_install.sh
@@ -1,13 +1,5 @@
 #!/bin/bash
-cd $2
-while read -r line; do
-    name="$line"
-    echo "Downloading $name..."
-    curl -O $name
-done < $1
-
-for pkg in $2/*.pkg; do
+for pkg in $1/*.pkg; do
     echo "Installing $pkg file..."
     installer -pkg $pkg -target /
 done
-


### PR DESCRIPTION
A mismatch with forked versions meant that packages became corrupted, and couldn't be installed. This fixes that issue.