### PR TITLE
Use correct parameters to install script in examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,13 +54,13 @@ To install all the downloaded packages use the following command:
 
 For mandatory files
 ```sh
- sudo ~/Downloads/lpx_links/app/install.sh ~/Desktop/lpx_download_links/mandatory_download_links.txt ~/Downloads/logic_content 
-```  
+ sudo ~/Downloads/lpx_links/app/install.sh ~/Downloads/logic_content
+```
 
 For all the packages
 ```sh
- sudo ~/Downloads/lpx_links/app/install.sh ~/Desktop/lpx_download_links/all_download_links.txt ~/Downloads/logic_content 
-```  
+ sudo ~/Downloads/lpx_links/app/install.sh ~/Downloads/logic_content
+```
 
 ### Development  
   


### PR DESCRIPTION
The install script looks for all '.pkg' files in the directory given in `$1`.

In the examples, the first positional parameter is a txt file, which means no packages will be found.