### PR TITLE
Add support of Mainstage

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 
 # lpx_links
 
-lpx_links is a utility to get the direct download links for the additional sample/sound content for Logic Pro X.
+lpx_links is a utility to get the direct download links for the additional sample/sound content for Logic Pro X and Mainstage.
 
 - It gets the most current links
 - Creates a text file with all the links in them
@@ -10,6 +10,8 @@ lpx_links is a utility to get the direct download links for the additional sampl
 Includes Mandatory only list. Thanks to _Matteo Ceruti_ aka [Matatata](https://github.com/matatata) for the idea.
    
 ### Version  
+0.0.10 - adds support to specify Mainstage app to get direct download links for sample/sound content
+
 0.0.9 - fixes issue where the install script attempted to re-download the pkg files 🤦‍
 
 0.0.8 - adds logic to resolve relative parents in download URLs & Readme updates.
@@ -20,10 +22,17 @@ Includes Mandatory only list. Thanks to _Matteo Ceruti_ aka [Matatata](https://g
 
 ## Usage
 
-Simply open the terminal and paste the command below. 
-  
+Simply open the terminal and paste one of the commands from below. 
+
+For Logic Pro X use the following command:
 ```sh  
- cd ~/Downloads; mkdir -p lpx_links/app ; cd lpx_links/app ; curl -#L https://goo.gl/nUrpPi | tar -xzv --strip-components 1 ; ./lpx_links.rb  
+ cd ~/Downloads; mkdir -p lpx_links/app ; cd lpx_links/app ; curl -#L https://goo.gl/nUrpPi | tar -xzv --strip-components 1 ; ./lpx_links.rb -n Logic
+  
+```
+
+For Mainstage use the following command:
+```sh  
+ cd ~/Downloads; mkdir -p lpx_links/app ; cd lpx_links/app ; curl -#L https://goo.gl/nUrpPi | tar -xzv --strip-components 1 ; ./lpx_links.rb -n Mainstage
   
 ```  
   
@@ -52,14 +61,8 @@ aria2c -c --auto-file-renaming=false -i ~/Desktop/lpx_download_links/all_downloa
   
 To install all the downloaded packages use the following command:  
 
-For mandatory files
 ```sh
- sudo ~/Downloads/lpx_links/app/install.sh ~/Desktop/lpx_download_links/mandatory_download_links.txt ~/Downloads/logic_content 
-```  
-
-For all the packages
-```sh
- sudo ~/Downloads/lpx_links/app/install.sh ~/Desktop/lpx_download_links/all_download_links.txt ~/Downloads/logic_content 
+ sudo ~/Downloads/lpx_links/app/install.sh ~/Downloads/logic_content 
 ```  
 
 ### Development  

--- a/lib/file_helpers.rb
+++ b/lib/file_helpers.rb
@@ -2,23 +2,37 @@
 module FileHelpers
   module_function
 
-  def plist_file_path
-    File.join(logic_app_path, plist_file_name)
+  def plist_file_path(app_name)
+    File.join(app_path(app_name), plist_file_name(app_name))
   end
 
-  def logic_app_path
-    path = "/Applications/Logic Pro X.app/Contents/Resources"
-    return path if File.exist?(path)
+  def app_path(app_name)
+    print "Searching in #{app_name}"
+    if (app_name == "LOGIC")
+      path = "/Applications/Logic Pro X.app/Contents/Resources"
+      return path if File.exist?(path)
+  
+      path = "/Applications/Logic Pro.app/Contents/Resources"
+      return path if File.exist?(path)
+  
+      raise "Logic Pro X not found"
+    end
 
-    path = "/Applications/Logic Pro.app/Contents/Resources"
-    return path if File.exist?(path)
+    if (app_name == "MAINSTAGE")
+      path = "/Applications/MainStage 3.app/Contents/Resources"
+      return path if File.exist?(path)
 
-    raise "Logic Pro X not found"
+      raise "Mainstage not found"
+    end
+
+    if (!path)
+      raise "No application paths found"
+    end
   end
 
-  # Returns current filename: i.e. 'logicpro1040.plist'
-  def plist_file_name
-    `cd '#{logic_app_path}' && find . -name  logicpro\*.plist`
+  # Returns current filename: i.e. 'logicpro1040.plist' or 'mainstage360.plist'
+  def plist_file_name(app_name)
+    `cd '#{app_path(app_name)}' && find . -name  logicpro\*.plist -o -name mainstage\*.plist`
       .gsub("./", "").chomp
   end
 

--- a/lib/file_helpers.rb
+++ b/lib/file_helpers.rb
@@ -7,7 +7,6 @@ module FileHelpers
   end
 
   def app_path(app_name)
-    print "Searching in #{app_name}"
     if (app_name == "LOGIC")
       path = "/Applications/Logic Pro X.app/Contents/Resources"
       return path if File.exist?(path)

--- a/lpx_links.rb
+++ b/lpx_links.rb
@@ -11,13 +11,14 @@ require_relative "lib/file_helpers"
 module LpxLinks
   module_function
   $app_name = "LOGIC" # default application name to read a list of packages from
-  options = {}
+
   OptionParser.new do |opts|
     opts.on("-nAPP_NAME", "--name=APP_NAME", "[ Logic | Mainstage ] Default is Logic") do |n|
       if (n.upcase! == "LOGIC" || n == "MAINSTAGE")
         $app_name = n
       else 
-        print "Application name can only be Logic or Mainstage"
+        print "Application name can only be Logic or Mainstage\n"
+        puts opts
         exit
       end
     end

--- a/lpx_links.rb
+++ b/lpx_links.rb
@@ -4,11 +4,28 @@ require "json"
 require "fileutils"
 require "pathname"
 require "uri"
+require "optparse"
 require_relative "lib/file_helpers"
 
 # read the plist, create a json & parse a list of links
 module LpxLinks
   module_function
+  $app_name = "LOGIC" # default application name to read a list of packages from
+  options = {}
+  OptionParser.new do |opts|
+    opts.on("-nAPP_NAME", "--name=APP_NAME", "[ Logic | Mainstage ] Default is Logic") do |n|
+      if (n.upcase! == "LOGIC" || n == "MAINSTAGE")
+        $app_name = n
+      else 
+        print "Application name can only be Logic or Mainstage"
+        exit
+      end
+    end
+    opts.on("-h", "--help", "Prints this help") do
+      puts opts
+      exit
+    end
+  end.parse!
 
   def run
     create_dirs
@@ -29,7 +46,7 @@ module LpxLinks
   end
 
   def convert_plist_to_json
-    `plutil -convert json \'#{FileHelpers.plist_file_path}\' -o /tmp/lgp_content.json`
+    `plutil -convert json \'#{FileHelpers.plist_file_path($app_name)}\' -o /tmp/lgp_content.json`
   end
 
   def packages


### PR DESCRIPTION
This PR is changing the following:

-  Adding support for searching sample/sound packages from Mainstage app.
- Additionally adding implementation of arguments to allow switching between Logic and Mainstage
- Updating Readme.md to reflect changes and fix packages installation procedure.