### PR TITLE
Fix install script path and usage instructions in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,8 +62,10 @@ aria2c -c --auto-file-renaming=false -i ~/Desktop/lpx_download_links/all_downloa
 To install all the downloaded packages use the following command:  
 
 ```sh
- sudo ~/Downloads/lpx_links/app/install.sh ~/Downloads/logic_content 
+ sudo ~/Downloads/lpx_links/install.sh ~/Downloads/logic_content 
 ```  
+
+> Note: The install script expects a directory containing `.pkg` files as its argument, not a text file with download links.
 
 ### Development  
   


### PR DESCRIPTION
## Description

This PR fixes issue #41 regarding incorrect install script examples in the README.

### Changes Made
- Fixed the path to the install script (changed from `~/Downloads/lpx_links/app/install.sh` to `~/Downloads/lpx_links/install.sh`)
- Added a clarifying note that the install script expects a directory containing `.pkg` files as its argument, not a text file with download links
- Improved documentation to prevent confusion when users try to install the packages

### Issue Reference
Fixes #41

### History Note
This PR replaces the original PR #26 created by @finwarman that was detached or lost when the repository changed from using the master to main branch convention.

### Context
The install script (`install.sh`) looks for all `.pkg` files in the directory given in `$1`:
```bash
for pkg in $1/*.pkg; do
    echo "Installing $pkg file..."
    installer -pkg $pkg -target /
done
```

This PR ensures the README correctly reflects the actual location of the script and clarifies how it should be used.