### PR TITLE
Change license from GPL-3.0 to MIT

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,14 +13,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - RuboCop configuration file (`.rubocop.yml`) with reasonable metric limits
 - RuboCop lint check to GitHub Actions CI workflow
 - `.ruby-version` file specifying Ruby 3.3.1
+- MIT License file
 
 ### Changed
+- **License changed from GPL-3.0 to MIT** for better compatibility and community alignment
 - Replaced global variable `$app_name` with module-level accessor pattern
 - Refactored `app_path` method to reduce complexity by extracting logic into separate methods
 - Converted `download_links` method to use keyword arguments (`only_mandatory:`)
 - Standardized string quotes (double → single) throughout codebase
 - Updated all tests to match new method signatures
 - Changed `ENV['HOME']` to `Dir.home` for better Ruby idioms
+- Updated README license badge and section with MIT license rationale
 
 ### Fixed
 - All RuboCop linting issues (115 offenses → 0 offenses)

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,22 @@
+MIT License
+
+Copyright (c) 2025 David Teren
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # lpx_links
 
 [![Ruby CI](https://github.com/davidteren/lpx_links/actions/workflows/ruby-ci.yml/badge.svg)](https://github.com/davidteren/lpx_links/actions/workflows/ruby-ci.yml)
-[![License: GPL v3](https://img.shields.io/badge/License-GPLv3-blue.svg)](https://www.gnu.org/licenses/gpl-3.0)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
 A Ruby utility to get direct download links for additional sample/sound content for Logic Pro X and MainStage.
 
@@ -102,8 +102,14 @@ See [TEST_WORKFLOW.md](TEST_WORKFLOW.md) for detailed testing documentation.
 - **Testing**: RSpec with SimpleCov for coverage tracking
 - **CI/CD**: GitHub Actions runs linting and tests on all PRs
   
-License  
-----  
+## License
 
-GNU General Public License, version 3 (GPL-3.0)  
-(http://opensource.org/licenses/GPL-3.0)
+This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.
+
+### Why MIT?
+
+This utility is licensed under MIT (changed from GPL-3.0) because:
+- **Simple utility tool** - Straightforward download link generator
+- **Maximum compatibility** - Can be used in any context without licensing concerns
+- **Community standard** - Aligns with most Ruby gems
+- **User-friendly** - No restrictions on commercial or private use


### PR DESCRIPTION
## Summary

Changes the project license from GPL-3.0 to MIT for better compatibility and community alignment.

## Changes

### Added
- ✅ MIT License file with proper copyright notice

### Changed
- ✅ README badge updated from GPL-3.0 to MIT
- ✅ README license section rewritten with rationale
- ✅ CHANGELOG updated to document license change

## Rationale for MIT License

MIT is more appropriate for this utility because:

1. **Simple utility tool** - This is a straightforward download link generator, not complex software requiring GPL protection
2. **Maximum compatibility** - Users can incorporate it into any project (commercial or private) without licensing concerns
3. **Community standard** - Most Ruby gems use MIT license
4. **User-friendly** - No "copyleft" restrictions that could discourage adoption
5. **No derivative works concern** - It's a standalone script, not a framework others will build upon

GPL-3.0 was overkill for this type of project. MIT provides the right balance of openness and flexibility.

## Testing

- ✅ No code changes - purely documentation and licensing
- ✅ All existing tests still pass
- ✅ No breaking changes

## Breaking Changes

None - this is a licensing change only. Existing users are not affected.