### PR TITLE
Fix user input prompts in curl|bash installation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **aria2 installation script** - Fixed `curl | bash` installation method by downloading binary from GitHub when not running from local repository
 - **aria2 installation script** - Added SHA256 checksum verification for binary integrity and security
 - **aria2 installation script** - Fixed user input prompts not working with `curl | bash` by reading from `/dev/tty` instead of stdin
+- **aria2 installation script** - Added non-interactive environment detection with graceful fallbacks (skip reinstall prompt, exit with helpful message for installation method choice)
 
 ### Changed
 - **README.md rewritten for musicians** - User-focused content with plain language, clear steps, and no technical jargon

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **aria2 installation script** - Fixed 401 Unauthorized error by bundling aria2 binary instead of downloading from GitHub Container Registry
 - **aria2 installation script** - Fixed `curl | bash` installation method by downloading binary from GitHub when not running from local repository
 - **aria2 installation script** - Added SHA256 checksum verification for binary integrity and security
+- **aria2 installation script** - Fixed user input prompts not working with `curl | bash` by reading from `/dev/tty` instead of stdin
 
 ### Changed
 - **README.md rewritten for musicians** - User-focused content with plain language, clear steps, and no technical jargon

--- a/scripts/install_aria2.sh
+++ b/scripts/install_aria2.sh
@@ -41,8 +41,17 @@ echo ""
 if command -v aria2c &> /dev/null; then
     CURRENT_VERSION=$(aria2c --version | head -n 1 | awk '{print $3}')
     print_yellow "aria2 is already installed (version $CURRENT_VERSION)"
-    read -p "Do you want to reinstall? (y/N): " -n 1 -r </dev/tty
-    echo
+
+    # Check if we can prompt for input (interactive environment)
+    if [ -c /dev/tty ]; then
+        read -p "Do you want to reinstall? (y/N): " -n 1 -r </dev/tty
+        echo
+    else
+        # In non-interactive environments, default to 'No' (safe default)
+        print_yellow "Non-interactive mode detected. Skipping reinstallation."
+        REPLY="n"
+    fi
+
     if [[ ! $REPLY =~ ^[Yy]$ ]]; then
         print_blue "Installation cancelled."
         exit 0
@@ -67,6 +76,17 @@ if command -v brew &> /dev/null; then
     echo "     - Apple Silicon (ARM64) only"
     echo "     - No automatic updates"
     echo ""
+
+    # Check if we can prompt for input (interactive environment)
+    if ! [ -c /dev/tty ]; then
+        print_red "Cannot prompt for installation method in a non-interactive environment."
+        print_yellow "Please run this script in an interactive terminal, or"
+        print_yellow "install aria2 directly using one of these methods:"
+        print_yellow "  - Homebrew: brew install aria2"
+        print_yellow "  - Clone repo and run: bash scripts/install_aria2.sh"
+        exit 1
+    fi
+
     read -p "Choose installation method (1=Homebrew, 2=Bundled): " -n 1 -r </dev/tty
     echo
     echo ""

--- a/scripts/install_aria2.sh
+++ b/scripts/install_aria2.sh
@@ -41,7 +41,7 @@ echo ""
 if command -v aria2c &> /dev/null; then
     CURRENT_VERSION=$(aria2c --version | head -n 1 | awk '{print $3}')
     print_yellow "aria2 is already installed (version $CURRENT_VERSION)"
-    read -p "Do you want to reinstall? (y/N): " -n 1 -r
+    read -p "Do you want to reinstall? (y/N): " -n 1 -r </dev/tty
     echo
     if [[ ! $REPLY =~ ^[Yy]$ ]]; then
         print_blue "Installation cancelled."
@@ -67,7 +67,7 @@ if command -v brew &> /dev/null; then
     echo "     - Apple Silicon (ARM64) only"
     echo "     - No automatic updates"
     echo ""
-    read -p "Choose installation method (1=Homebrew, 2=Bundled): " -n 1 -r
+    read -p "Choose installation method (1=Homebrew, 2=Bundled): " -n 1 -r </dev/tty
     echo
     echo ""
 


### PR DESCRIPTION
### **User description**
## Problem

When running the aria2 installation script via `curl | bash`, the user prompts don't work:
- Homebrew choice prompt shows but doesn't wait for input
- Immediately shows "Invalid choice" error
- User never gets a chance to select an option

## Root Cause

When a script is piped through `curl | bash`, stdin is being used to feed the script itself. The `read` command tries to read from stdin, but there's no user input available - it just gets EOF immediately.

## Solution

Changed both user input prompts to read from `/dev/tty` instead of stdin:
- Homebrew installation method choice prompt
- Reinstall confirmation prompt (when aria2 is already installed)

```bash
# Before:
read -p "Choose installation method (1=Homebrew, 2=Bundled): " -n 1 -r

# After:
read -p "Choose installation method (1=Homebrew, 2=Bundled): " -n 1 -r </dev/tty
```

## Testing

✅ Script syntax validation passes
✅ Prompts now work correctly with `curl | bash`
✅ User can select installation method
✅ Reinstall prompt works when aria2 is already installed

## Files Changed

- `scripts/install_aria2.sh` - Fixed both read prompts to use `/dev/tty`
- `CHANGELOG.md` - Documented the fix

## Impact

- **Low risk** - Only changes how input is read, no logic changes
- **High value** - Makes the recommended installation method actually work
- **User-facing** - Directly fixes the broken user experience


___

### **PR Type**
Bug fix


___

### **Description**
- Fixed user input prompts not working with `curl | bash` installation

- Changed read commands to use `/dev/tty` instead of stdin

- Resolves immediate "Invalid choice" error without user input

- Updated changelog to document the fix


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["curl | bash"] --> B["Script reads from stdin"]
  B --> C["No user input available"]
  C --> D["Immediate EOF/Invalid choice"]
  E["Fixed: read from /dev/tty"] --> F["User can provide input"]
  F --> G["Prompts work correctly"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>install_aria2.sh</strong><dd><code>Fix stdin prompts for piped execution</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

scripts/install_aria2.sh

<ul><li>Modified reinstall confirmation prompt to read from <code>/dev/tty</code><br> <li> Modified installation method choice prompt to read from <code>/dev/tty</code><br> <li> Both <code>read</code> commands now work with piped script execution</ul>


</details>


  </td>
  <td><a href="https://github.com/davidteren/lpx_links/pull/72/files#diff-63537e81712955133ddd005d6fb3b1bbc5dd176c62b096310f649d635586da8e">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CHANGELOG.md</strong><dd><code>Document stdin prompt fix</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

CHANGELOG.md

<ul><li>Added entry documenting the fix for user input prompts<br> <li> Explains the issue was with <code>curl | bash</code> installation method</ul>


</details>


  </td>
  <td><a href="https://github.com/davidteren/lpx_links/pull/72/files#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4ed">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

